### PR TITLE
Hydrate venv after exec zsh; finish AI-rewire migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,16 +12,6 @@ backups/*
 !backups/README.txt
 .DS_STORE
 .env
-claude/*
-!claude/AGENTS.md
-!claude/CLAUDE.md
-claude/plugins/
-!claude/settings.json
-!claude/utility-scripts/
-!claude/skills/
-!claude/references/
-!claude/hooks/
-!claude/commands/
 ipython/*
 !ipython/README.md
 !ipython/profile_default/

--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -1,3 +1,0 @@
-# Shared Agent Instructions
-
-@~/generic/dotfiles/ai-harness/AGENTS.md

--- a/config/apt-packages.txt
+++ b/config/apt-packages.txt
@@ -49,3 +49,4 @@ software-properties-common
 # - markdownlint-cli
 # - stylua (via cargo or npm, not in apt)
 # NOTE: claude-code is installed via npm or curl installer
+# NOTE: codex (@openai/codex) and copilot (@github/copilot) are installed via npm in install.sh

--- a/config/brew-packages.txt
+++ b/config/brew-packages.txt
@@ -58,3 +58,5 @@ borders
 
 # AI tools
 claude-code
+codex
+copilot-cli

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -1,226 +1,58 @@
 {
-  "LazyVim": {
-    "branch": "main",
-    "commit": "83d90f339defdb109a6ede333865a66ffc7ef6aa"
-  },
-  "SchemaStore.nvim": {
-    "branch": "main",
-    "commit": "6db1246640e9e1bdf8a1d1f6d27a940fc0a572d5"
-  },
-  "blink-cmp-dictionary": {
-    "branch": "master",
-    "commit": "35142bba869b869715e91a99d2f46bcf93fca4ae"
-  },
-  "blink.cmp": {
-    "branch": "main",
-    "commit": "78336bc89ee5365633bcf754d93df01678b5c08f"
-  },
-  "buffergolf.nvim": {
-    "branch": "main",
-    "commit": "606fcfd7775950f6c80a98d0580de3a3cd92734a"
-  },
-  "bufferline.nvim": {
-    "branch": "main",
-    "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3"
-  },
-  "bullets.vim": {
-    "branch": "master",
-    "commit": "28c22791153a90bb61a86fbeeae0f812e048ade7"
-  },
-  "catppuccin": {
-    "branch": "main",
-    "commit": "426dbebe06b5c69fd846ceb17b42e12f890aedf1"
-  },
-  "codediff.nvim": {
-    "branch": "main",
-    "commit": "8afc229d38dc13ce71b2ffbb860084b2c726e061"
-  },
-  "conform.nvim": {
-    "branch": "master",
-    "commit": "dca1a190aa85f9065979ef35802fb77131911106"
-  },
-  "copilot.lua": {
-    "branch": "master",
-    "commit": "78c638293f0ea6a2245eca46e9933ee271792d7e"
-  },
-  "dial.nvim": {
-    "branch": "master",
-    "commit": "f2634758455cfa52a8acea6f142dcd6271a1bf57"
-  },
-  "flash.nvim": {
-    "branch": "main",
-    "commit": "fcea7ff883235d9024dc41e638f164a450c14ca2"
-  },
-  "friendly-snippets": {
-    "branch": "main",
-    "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9"
-  },
-  "fyler.nvim": {
-    "branch": "stable",
-    "commit": "5e24ff1c46528d8dc2e61c22cc21fb590f626e1e"
-  },
-  "gitsigns.nvim": {
-    "branch": "main",
-    "commit": "20ad4419564d6e22b189f6738116b38871082332"
-  },
-  "grug-far.nvim": {
-    "branch": "main",
-    "commit": "21790e59dd0109a92a70cb874dd002af186314f5"
-  },
-  "inc-rename.nvim": {
-    "branch": "main",
-    "commit": "0074b551a17338ccdcd299bd86687cc651bcb33d"
-  },
-  "lazy.nvim": {
-    "branch": "main",
-    "commit": "85c7ff3711b730b4030d03144f6db6375044ae82"
-  },
-  "lazydev.nvim": {
-    "branch": "main",
-    "commit": "ff2cbcba459b637ec3fd165a2be59b7bbaeedf0d"
-  },
-  "lualine.nvim": {
-    "branch": "master",
-    "commit": "131a558e13f9f28b15cd235557150ccb23f89286"
-  },
-  "markdown-preview.nvim": {
-    "branch": "master",
-    "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee"
-  },
-  "mason-lspconfig.nvim": {
-    "branch": "main",
-    "commit": "0c2823e0418f3d9230ff8b201c976e84de1cb401"
-  },
-  "mason.nvim": {
-    "branch": "main",
-    "commit": "cb8445f8ce85d957416c106b780efd51c6298f89"
-  },
-  "mini.ai": {
-    "branch": "main",
-    "commit": "43eb2074843950a3a25aae56a5f41362ec043bfa"
-  },
-  "mini.comment": {
-    "branch": "main",
-    "commit": "8e5ff3ed3cc0e8f216617aae01020c00c20f7a87"
-  },
-  "mini.diff": {
-    "branch": "main",
-    "commit": "0ee0459152b141c0e1b0931eb6949105be4850a9"
-  },
-  "mini.files": {
-    "branch": "main",
-    "commit": "3e247eb12ca8c05622ceb8745f9004f761b22ef8"
-  },
-  "mini.hipatterns": {
-    "branch": "main",
-    "commit": "9eff319bbe66adfaf781a0d0e174baa08ba94909"
-  },
-  "mini.icons": {
-    "branch": "main",
-    "commit": "bac6317300e205335df425296570d84322730067"
-  },
-  "mini.pairs": {
-    "branch": "main",
-    "commit": "d5a29b6254dad07757832db505ea5aeab9aad43a"
-  },
-  "mini.surround": {
-    "branch": "main",
-    "commit": "2715e04bea3ec9244f15b421dc5b18c0fe326210"
-  },
-  "noice.nvim": {
-    "branch": "main",
-    "commit": "7bfd942445fb63089b59f97ca487d605e715f155"
-  },
-  "nui.nvim": {
-    "branch": "main",
-    "commit": "de740991c12411b663994b2860f1a4fd0937c130"
-  },
-  "nvim-lint": {
-    "branch": "master",
-    "commit": "eab58b48eb11d7745c11c505e0f3057165902461"
-  },
-  "nvim-lspconfig": {
-    "branch": "master",
-    "commit": "31026a13eefb20681124706a79fc1df6bf11ab27"
-  },
-  "nvim-treesitter": {
-    "branch": "main",
-    "commit": "4916d6592ede8c07973490d9322f187e07dfefac"
-  },
-  "nvim-treesitter-context": {
-    "branch": "master",
-    "commit": "b0c45cefe2c8f7b55fc46f34e563bc428ef99636"
-  },
-  "nvim-treesitter-textobjects": {
-    "branch": "main",
-    "commit": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e"
-  },
-  "nvim-ts-autotag": {
-    "branch": "main",
-    "commit": "88c1453db4ba7dd24131086fe51fdf74e587d275"
-  },
-  "nvim-ts-context-commentstring": {
-    "branch": "main",
-    "commit": "6141a40173c6efa98242dc951ed4b6f892c97027"
-  },
-  "obsidian.nvim": {
-    "branch": "main",
-    "commit": "5186cba27b256daae5f824b2789e016161f0b20c"
-  },
-  "persistence.nvim": {
-    "branch": "main",
-    "commit": "b20b2a7887bd39c1a356980b45e03250f3dce49c"
-  },
-  "plenary.nvim": {
-    "branch": "master",
-    "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b"
-  },
-  "render-markdown.nvim": {
-    "branch": "main",
-    "commit": "3f3eea97b80839f629c951ca660ffd125bfa5b34"
-  },
-  "sidekick.nvim": {
-    "branch": "main",
-    "commit": "208e1c5b8170c01fd1d07df0139322a76479b235"
-  },
-  "snacks.nvim": {
-    "branch": "main",
-    "commit": "ad9ede6a9cddf16cedbd31b8932d6dcdee9b716e"
-  },
-  "sonarlint.nvim": {
-    "branch": "main",
-    "commit": "1d49a469265e271f02b6efcf09c215e4560bd5fa"
-  },
-  "tiny-glimmer.nvim": {
-    "branch": "main",
-    "commit": "cc285167914e947fc130523d02927fdaf24636a6"
-  },
-  "tiny-inline-diagnostic.nvim": {
-    "branch": "main",
-    "commit": "147af4e49f51dd48f41972de26552872b8ba7b25"
-  },
-  "todo-comments.nvim": {
-    "branch": "main",
-    "commit": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668"
-  },
-  "tokyonight.nvim": {
-    "branch": "main",
-    "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6"
-  },
-  "trouble.nvim": {
-    "branch": "main",
-    "commit": "bd67efe408d4816e25e8491cc5ad4088e708a69a"
-  },
-  "ts-comments.nvim": {
-    "branch": "main",
-    "commit": "123a9fb12e7229342f807ec9e6de478b1102b041"
-  },
-  "vim-tmux-navigator": {
-    "branch": "master",
-    "commit": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432"
-  },
-  "which-key.nvim": {
-    "branch": "main",
-    "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a"
-  }
+  "LazyVim": { "branch": "main", "commit": "83d90f339defdb109a6ede333865a66ffc7ef6aa" },
+  "SchemaStore.nvim": { "branch": "main", "commit": "6db1246640e9e1bdf8a1d1f6d27a940fc0a572d5" },
+  "blink-cmp-dictionary": { "branch": "master", "commit": "35142bba869b869715e91a99d2f46bcf93fca4ae" },
+  "blink.cmp": { "branch": "main", "commit": "78336bc89ee5365633bcf754d93df01678b5c08f" },
+  "buffergolf.nvim": { "branch": "main", "commit": "606fcfd7775950f6c80a98d0580de3a3cd92734a" },
+  "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
+  "bullets.vim": { "branch": "master", "commit": "28c22791153a90bb61a86fbeeae0f812e048ade7" },
+  "catppuccin": { "branch": "main", "commit": "426dbebe06b5c69fd846ceb17b42e12f890aedf1" },
+  "codediff.nvim": { "branch": "main", "commit": "8afc229d38dc13ce71b2ffbb860084b2c726e061" },
+  "conform.nvim": { "branch": "master", "commit": "dca1a190aa85f9065979ef35802fb77131911106" },
+  "copilot.lua": { "branch": "master", "commit": "78c638293f0ea6a2245eca46e9933ee271792d7e" },
+  "dial.nvim": { "branch": "master", "commit": "f2634758455cfa52a8acea6f142dcd6271a1bf57" },
+  "flash.nvim": { "branch": "main", "commit": "fcea7ff883235d9024dc41e638f164a450c14ca2" },
+  "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
+  "fyler.nvim": { "branch": "stable", "commit": "5e24ff1c46528d8dc2e61c22cc21fb590f626e1e" },
+  "gitsigns.nvim": { "branch": "main", "commit": "20ad4419564d6e22b189f6738116b38871082332" },
+  "grug-far.nvim": { "branch": "main", "commit": "21790e59dd0109a92a70cb874dd002af186314f5" },
+  "inc-rename.nvim": { "branch": "main", "commit": "0074b551a17338ccdcd299bd86687cc651bcb33d" },
+  "lazy.nvim": { "branch": "main", "commit": "85c7ff3711b730b4030d03144f6db6375044ae82" },
+  "lazydev.nvim": { "branch": "main", "commit": "ff2cbcba459b637ec3fd165a2be59b7bbaeedf0d" },
+  "lualine.nvim": { "branch": "master", "commit": "131a558e13f9f28b15cd235557150ccb23f89286" },
+  "markdown-preview.nvim": { "branch": "master", "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee" },
+  "mason-lspconfig.nvim": { "branch": "main", "commit": "0c2823e0418f3d9230ff8b201c976e84de1cb401" },
+  "mason.nvim": { "branch": "main", "commit": "cb8445f8ce85d957416c106b780efd51c6298f89" },
+  "mini.ai": { "branch": "main", "commit": "43eb2074843950a3a25aae56a5f41362ec043bfa" },
+  "mini.comment": { "branch": "main", "commit": "8e5ff3ed3cc0e8f216617aae01020c00c20f7a87" },
+  "mini.diff": { "branch": "main", "commit": "0ee0459152b141c0e1b0931eb6949105be4850a9" },
+  "mini.files": { "branch": "main", "commit": "3e247eb12ca8c05622ceb8745f9004f761b22ef8" },
+  "mini.hipatterns": { "branch": "main", "commit": "9eff319bbe66adfaf781a0d0e174baa08ba94909" },
+  "mini.icons": { "branch": "main", "commit": "bac6317300e205335df425296570d84322730067" },
+  "mini.pairs": { "branch": "main", "commit": "d5a29b6254dad07757832db505ea5aeab9aad43a" },
+  "mini.surround": { "branch": "main", "commit": "2715e04bea3ec9244f15b421dc5b18c0fe326210" },
+  "noice.nvim": { "branch": "main", "commit": "7bfd942445fb63089b59f97ca487d605e715f155" },
+  "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
+  "nvim-lint": { "branch": "master", "commit": "eab58b48eb11d7745c11c505e0f3057165902461" },
+  "nvim-lspconfig": { "branch": "master", "commit": "31026a13eefb20681124706a79fc1df6bf11ab27" },
+  "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
+  "nvim-treesitter-context": { "branch": "master", "commit": "b0c45cefe2c8f7b55fc46f34e563bc428ef99636" },
+  "nvim-treesitter-textobjects": { "branch": "main", "commit": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e" },
+  "nvim-ts-autotag": { "branch": "main", "commit": "88c1453db4ba7dd24131086fe51fdf74e587d275" },
+  "nvim-ts-context-commentstring": { "branch": "main", "commit": "6141a40173c6efa98242dc951ed4b6f892c97027" },
+  "obsidian.nvim": { "branch": "main", "commit": "5186cba27b256daae5f824b2789e016161f0b20c" },
+  "persistence.nvim": { "branch": "main", "commit": "b20b2a7887bd39c1a356980b45e03250f3dce49c" },
+  "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "render-markdown.nvim": { "branch": "main", "commit": "3f3eea97b80839f629c951ca660ffd125bfa5b34" },
+  "sidekick.nvim": { "branch": "main", "commit": "208e1c5b8170c01fd1d07df0139322a76479b235" },
+  "snacks.nvim": { "branch": "main", "commit": "ad9ede6a9cddf16cedbd31b8932d6dcdee9b716e" },
+  "sonarlint.nvim": { "branch": "main", "commit": "1d49a469265e271f02b6efcf09c215e4560bd5fa" },
+  "tiny-glimmer.nvim": { "branch": "main", "commit": "cc285167914e947fc130523d02927fdaf24636a6" },
+  "tiny-inline-diagnostic.nvim": { "branch": "main", "commit": "147af4e49f51dd48f41972de26552872b8ba7b25" },
+  "todo-comments.nvim": { "branch": "main", "commit": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668" },
+  "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },
+  "trouble.nvim": { "branch": "main", "commit": "bd67efe408d4816e25e8491cc5ad4088e708a69a" },
+  "ts-comments.nvim": { "branch": "main", "commit": "123a9fb12e7229342f807ec9e6de478b1102b041" },
+  "vim-tmux-navigator": { "branch": "master", "commit": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -484,6 +484,27 @@ main() {
     else
       log "stylua already installed—skipping re-install"
     fi
+
+    # AI CLIs - on macOS these are casks (codex, copilot-cli); on Linux use npm
+    if ! command -v codex &> /dev/null; then
+      log "Installing OpenAI Codex CLI via npm…"
+      sudo_if_needed npm install -g @openai/codex || {
+        err "Codex CLI install failed"
+        exit 1
+      }
+    else
+      log "Codex CLI already installed—skipping re-install"
+    fi
+
+    if ! command -v copilot &> /dev/null; then
+      log "Installing GitHub Copilot CLI via npm…"
+      sudo_if_needed npm install -g @github/copilot || {
+        err "Copilot CLI install failed"
+        exit 1
+      }
+    else
+      log "Copilot CLI already installed—skipping re-install"
+    fi
   fi
 
   # Note: dust is only installed via brew on macOS, not available on Linux

--- a/zsh/functions/venv.zsh
+++ b/zsh/functions/venv.zsh
@@ -7,6 +7,13 @@ typeset -gA _VENV_CACHE  # dir -> venv path (or empty)
 # Auto-activate virtual environments based on directory
 _auto_activate_venv() {
   local start="$PWD" dir="$PWD" venv=""
+
+  # `exec zsh` preserves environment variables but not shell functions.
+  # Rehydrate an inherited active venv so `deactivate` exists again.
+  if [[ -n "$VIRTUAL_ENV" ]] && ! whence -w deactivate >/dev/null 2>&1 && [[ -r "$VIRTUAL_ENV/bin/activate" ]]; then
+    source "$VIRTUAL_ENV/bin/activate"
+  fi
+
   # Cache hit?
   if [[ -n "${_VENV_CACHE[$start]-}" ]]; then
     venv="${_VENV_CACHE[$start]}"
@@ -22,8 +29,8 @@ _auto_activate_venv() {
   fi
 
   if [[ -n "$venv" ]]; then
-    # Only source if it's a different venv than the active one
-    if [[ "$VIRTUAL_ENV" != "$venv" ]]; then
+    # Re-source if the shell inherited VIRTUAL_ENV/PATH without the deactivate function.
+    if [[ "$VIRTUAL_ENV" != "$venv" ]] || ! whence -w deactivate >/dev/null 2>&1; then
       source "$venv/bin/activate"
     fi
   fi


### PR DESCRIPTION
## Summary
Originally just the venv-hydration fix; grew to clean up dangling work from the AI-rewire commit (`19c000e`) so `main` is in a tidy state.

**Commits (atomic):**
1. `rehydrate venv after exec zsh` — re-source the activate script when `$VIRTUAL_ENV` is inherited but `deactivate` is missing (the post-`exec zsh` case).
2. `Drop legacy claude/* gitignore hacks and dead AGENTS.md shim` — file-level claude symlinks make the "ignore everything except tracked" block obsolete; `claude/AGENTS.md` was an unreferenced shim.
3. `Wire codex and copilot CLIs into install.sh` — symlinks to `~/.codex/` and `~/.copilot/` already existed but nothing installed the CLIs. macOS via brew casks (`codex`, `copilot-cli`); Linux via npm (`@openai/codex`, `@github/copilot`).
4. `Normalize nvim/lazy-lock.json to Lazy's single-line format` — same plugins/SHAs, just stops format churn on every nvim run.

## Test plan
- [x] Activate a venv, `exec zsh`, confirm `deactivate` is defined.
- [x] `bash scripts/symlink.sh` migrates legacy `~/.claude` symlink to a real dir without losing runtime state.
- [x] `bash scripts/install.sh` is idempotent; installs codex + copilot-cli on a fresh macOS run.
- [x] `git status` is clean after opening nvim (no recurring lazy-lock diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)