### PR TITLE
fix: reap rail-only windows the instant their content pane dies

### DIFF
--- a/tmux/.config/tmux/scripts/reap-rail-window.sh
+++ b/tmux/.config/tmux/scripts/reap-rail-window.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Kill a window the instant it's left holding nothing but its rail pane.
+#
+# Without this, `exit` in the last content pane leaves the display-only
+# rail (@rail=1) alone; tmux stretches it across the whole window and the
+# daemon's selfHeal reconcile (tuis/rail/src/daemon.ts) only catches it on
+# its next tick, so the stretched rail flickers on screen for up to one
+# tick. This hook makes the reap instant; selfHeal stays as the backstop
+# ("hooks make this instant, this reconcile makes it inevitable").
+#
+# Called by: set-hook -g pane-exited (tmux.conf), with the dying pane's
+# window in $1 (#{window_id}). Falls back to scanning every window if that
+# format ever expands empty (observed non-empty on tmux 3.7).
+#
+# If the window's last pane is the rail, kill-window ends the session too
+# when it's the session's only window — same as selfHeal's own reap.
+
+reap_if_rail_only() {
+  window="$1"
+  panes="$(tmux list-panes -t "$window" -F '#{@rail}' 2>/dev/null)" || return 0
+  [ -n "$panes" ] || return 0
+  # Any pane without @rail=1 means real content survives; leave it alone.
+  echo "$panes" | grep -qv '^1$' && return 0
+  tmux kill-window -t "$window" 2>/dev/null
+}
+
+window_id="$1"
+
+if [ -n "$window_id" ]; then
+  reap_if_rail_only "$window_id"
+else
+  tmux list-windows -a -F '#{window_id}' 2>/dev/null | while IFS= read -r window; do
+    reap_if_rail_only "$window"
+  done
+fi

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -158,6 +158,12 @@ set-hook -g after-select-pane 'run-shell -b "~/.config/tmux/scripts/track-pane.s
 set-hook -g session-window-changed 'run-shell -b "~/.config/tmux/scripts/track-pane.sh"'
 set-hook -g client-session-changed 'run-shell -b "~/.config/tmux/scripts/track-pane.sh"'
 bind -n M-l run-shell '~/.config/tmux/scripts/go-back-pane.sh'
+
+# `exit` in a shell pane kills that pane but leaves its window alive if a
+# rail pane is still in it; tmux stretches the display-only rail across
+# the whole window until the daemon's next tick reaps it, flickering. Reap
+# on the spot instead — the daemon's selfHeal remains the backstop.
+set-hook -g pane-exited 'run-shell -b "~/.config/tmux/scripts/reap-rail-window.sh #{window_id}"'
 # ----- window navigation on the alt layer ------------------------------
 bind-key -n M-1 select-window -t 1
 bind-key -n M-2 select-window -t 2


### PR DESCRIPTION
## Summary
- `exit` in a shell pane kills that pane, but its window survives with only the display-only rail (`@rail`=1) left in it. tmux stretches the 24-column rail across the full window width for up to one daemon tick (~250ms) before selfHeal reaps it — visible as a flicker.
- Adds `tmux/.config/tmux/scripts/reap-rail-window.sh`: given a window id, kills the window immediately if every remaining pane in it is a rail. Falls back to scanning all windows if the hook's `#{window_id}` format ever expands empty (verified non-empty on tmux 3.7, but guarded regardless).
- Registers it via `set-hook -g pane-exited` in `tmux.conf`, next to the existing pane-history hooks.
- `tuis/rail`'s daemon `selfHeal` is untouched and remains the inevitable backstop, per its own stated philosophy.
- Edge case (matches existing selfHeal behavior): if the session's only window is rail-only, `kill-window` ends the session too.

**Post-merge:** run `tmux source-file ~/.config/tmux/tmux.conf` on the live server to pick up the hook (not done by this PR — it's a worktree).

## Test plan
- [x] `uvx prek run --all-files` — shellcheck/shfmt clean, all hooks pass.
- [x] Scratch tmux server (`tmux -L reaptest`), fake rail pane (`@rail`=1), natural pane exit (`exit` typed into the shell, not `kill-pane`) → window reaped instantly.
- [x] Window with two content panes, one exits → window survives.
- [x] Session's only window is rail-only, its content pane exits → session ends (matches selfHeal's own reap).
- [ ] Ryan confirms the flicker is gone in a live demo before merge (gate is absolute per handoff — **do not merge**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)