### PR TITLE
Add bat and port sketchybar onto the v2 theme system

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,11 +59,12 @@ repos:
   # ---------------------------------------------------------------- Shell
   # POSIX sh only — zsh interactive config is deliberately unlinted
   # (shellcheck has no zsh dialect; see docs/v2-plan.md#shell-language-split).
+  # sketchybar's plugins are zsh too (shebang, not extension), same reason.
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
-        exclude: '\.zsh$|^zsh/'
+        exclude: '\.zsh$|^zsh/|^sketchybar/'
 
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ resolves at runtime via `PATH` and `$HOME`; there is no templating.
 | `ghostty`    | terminal emulator (macOS)                                                                             |
 | `tmux`       | multiplexer, with [workmux](https://github.com/raine/workmux) for worktree-parallel agents and status |
 | `git`        | git + gh, delta as pager                                                                              |
+| `bat`        | `cat` with syntax highlighting, themed with Catppuccin                                                |
 | `theme`      | the theming pipeline (below)                                                                          |
 | `ai-harness` | shared instructions, skills, and hooks for coding agents                                              |
 | `tiers`      | which packages install on which machines                                                              |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ resolves at runtime via `PATH` and `$HOME`; there is no templating.
 | `nvim`       | LazyVim-based Neovim. Personal plugins live in `nvim/dev/` as real, extractable plugins               |
 | `zsh`        | zsh with a starship prompt and automatic `.venv` activation                                           |
 | `ghostty`    | terminal emulator (macOS)                                                                             |
+| `sketchybar` | macOS menu bar replacement, aerospace/battery/cpu/memory/wifi widgets                                 |
 | `tmux`       | multiplexer, with [workmux](https://github.com/raine/workmux) for worktree-parallel agents and status |
 | `git`        | git + gh, delta as pager                                                                              |
 | `bat`        | `cat` with syntax highlighting, themed with Catppuccin                                                |

--- a/bat/.config/bat/config
+++ b/bat/.config/bat/config
@@ -1,0 +1,2 @@
+--theme-dark="Catppuccin Mocha"
+--theme-light="Catppuccin Latte"

--- a/bat/.config/bat/themes/Catppuccin Latte.tmTheme
+++ b/bat/.config/bat/themes/Catppuccin Latte.tmTheme
@@ -1,0 +1,2112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>Catppuccin Latte</string>
+    <key>semanticClass</key>
+    <string>theme.light.catppuccin-latte</string>
+    <key>uuid</key>
+    <string>96a262cd-4b2f-49f5-9125-8dd0077cbfe1</string>
+    <key>author</key>
+    <string>Catppuccin Org</string>
+    <key>colorSpaceName</key>
+    <string>sRGB</string>
+    <key>settings</key>
+    <array>
+      <dict>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#eff1f5</string>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+          <key>caret</key>
+          <string>#dc8a78</string>
+          <key>lineHighlight</key>
+          <string>#ccd0da</string>
+          <key>misspelling</key>
+          <string>#d20f39</string>
+          <key>accent</key>
+          <string>#8839ef</string>
+          <key>selection</key>
+          <string>#7c7f934d</string>
+          <key>activeGuide</key>
+          <string>#bcc0cc</string>
+          <key>findHighlight</key>
+          <string>#a9daf0</string>
+          <key>gutterForeground</key>
+          <string>#8c8fa1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Basic text &amp; variable names (incl. leading punctuation)</string>
+        <key>scope</key>
+        <string>text, source, variable.other.readwrite, punctuation.definition.variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Parentheses, Brackets, Braces</string>
+        <key>scope</key>
+        <string>punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7c7f93</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Comments</string>
+        <key>scope</key>
+        <string>comment, punctuation.definition.comment</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7c7f93</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>string, punctuation.definition.string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#40a02b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>constant.character.escape</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Booleans, constants, numbers</string>
+        <key>scope</key>
+        <string>constant.numeric, variable.other.constant, entity.name.constant, constant.language.boolean, constant.language.false, constant.language.true, keyword.other.unit.user-defined, keyword.other.unit.suffix.floating-point</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>keyword, keyword.operator.word, keyword.operator.new, variable.language.super, support.type.primitive, storage.type, storage.modifier, punctuation.definition.keyword</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.tag.documentation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Punctuation</string>
+        <key>scope</key>
+        <string>keyword.operator, punctuation.accessor, punctuation.definition.generic, meta.function.closure punctuation.section.parameters, punctuation.definition.tag, punctuation.separator.key-value</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.function, meta.function-call.method, support.function, support.function.misc, variable.function</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Classes</string>
+        <key>scope</key>
+        <string>entity.name.class, entity.other.inherited-class, support.class, meta.function-call.constructor, entity.name.struct</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Enum</string>
+        <key>scope</key>
+        <string>entity.name.enum</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Enum member</string>
+        <key>scope</key>
+        <string>meta.enum variable.other.readwrite, variable.other.enummember</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Object properties</string>
+        <key>scope</key>
+        <string>meta.property.object</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Types</string>
+        <key>scope</key>
+        <string>meta.type, meta.type-alias, support.type, entity.name.type</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Decorators</string>
+        <key>scope</key>
+        <string>meta.annotation variable.function, meta.annotation variable.annotation.function, meta.annotation punctuation.definition.annotation, meta.decorator, punctuation.decorator</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>variable.parameter, meta.function.parameters</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Built-ins</string>
+        <key>scope</key>
+        <string>constant.language, support.function.builtin</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.other.attribute-name.documentation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Preprocessor directives</string>
+        <key>scope</key>
+        <string>keyword.control.directive, punctuation.definition.directive</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Type parameters</string>
+        <key>scope</key>
+        <string>punctuation.definition.typeparameters</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#04a5e5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Namespaces</string>
+        <key>scope</key>
+        <string>entity.name.namespace</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Property names (left hand assignments in json/yaml/css)</string>
+        <key>scope</key>
+        <string>support.type.property-name.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>This/Self keyword</string>
+        <key>scope</key>
+        <string>variable.language.this, variable.language.this punctuation.definition.variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Object properties</string>
+        <key>scope</key>
+        <string>variable.object.property</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>String template interpolation</string>
+        <key>scope</key>
+        <string>string.template variable, string variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>`new` as bold</string>
+        <key>scope</key>
+        <string>keyword.operator.new</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C++ extern keyword</string>
+        <key>scope</key>
+        <string>storage.modifier.specifier.extern.cpp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C++ scope resolution</string>
+        <key>scope</key>
+        <string>entity.name.scope-resolution.template.call.cpp, entity.name.scope-resolution.parameter.cpp, entity.name.scope-resolution.cpp, entity.name.scope-resolution.function.definition.cpp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C++ doc keywords</string>
+        <key>scope</key>
+        <string>storage.type.class.doxygen</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C++ operators</string>
+        <key>scope</key>
+        <string>storage.modifier.reference.cpp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C# Interpolated Strings</string>
+        <key>scope</key>
+        <string>meta.interpolation.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C# xml-style docs</string>
+        <key>scope</key>
+        <string>comment.block.documentation.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Classes, reflecting the className color in JSX</string>
+        <key>scope</key>
+        <string>source.css entity.other.attribute-name.class.css, entity.other.attribute-name.parent-selector.css punctuation.definition.entity.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Operators</string>
+        <key>scope</key>
+        <string>punctuation.separator.operator.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Pseudo classes</string>
+        <key>scope</key>
+        <string>source.css entity.other.attribute-name.pseudo-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>source.css constant.other.unicode-range</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>source.css variable.parameter.url</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#40a02b</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS vendored property names</string>
+        <key>scope</key>
+        <string>support.type.vendored.property-name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#04a5e5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Less/SCSS right-hand variables (@/$-prefixed)</string>
+        <key>scope</key>
+        <string>source.css meta.property-value variable, source.css meta.property-value variable.other.less, source.css meta.property-value variable.other.less punctuation.definition.variable.less, meta.definition.variable.scss</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS variables (--prefixed)</string>
+        <key>scope</key>
+        <string>source.css meta.property-list variable, meta.property-list variable.other.less, meta.property-list variable.other.less punctuation.definition.variable.less</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Percentage values, styled the same as numbers</string>
+        <key>scope</key>
+        <string>keyword.other.unit.percentage.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Attribute selectors, styled the same as strings</string>
+        <key>scope</key>
+        <string>source.css meta.attribute-selector</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#40a02b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON/YAML keys, other left-hand assignments</string>
+        <key>scope</key>
+        <string>keyword.other.definition.ini, punctuation.support.type.property-name.json, support.type.property-name.json, punctuation.support.type.property-name.toml, support.type.property-name.toml, entity.name.tag.yaml, punctuation.support.type.property-name.yaml, support.type.property-name.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON/YAML constants</string>
+        <key>scope</key>
+        <string>constant.language.json, constant.language.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>YAML anchors</string>
+        <key>scope</key>
+        <string>entity.name.type.anchor.yaml, variable.other.alias.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>TOML tables / ini groups</string>
+        <key>scope</key>
+        <string>support.type.property-name.table, entity.name.section.group-title.ini</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>TOML dates</string>
+        <key>scope</key>
+        <string>constant.other.time.datetime.offset.toml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>YAML anchor puctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.anchor.yaml, punctuation.definition.alias.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>YAML triple dashes</string>
+        <key>scope</key>
+        <string>entity.other.document.begin.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup Diff</string>
+        <key>scope</key>
+        <string>markup.changed.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff</string>
+        <key>scope</key>
+        <string>meta.diff.header.from-file, meta.diff.header.to-file, punctuation.definition.from-file.diff, punctuation.definition.to-file.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Inserted</string>
+        <key>scope</key>
+        <string>markup.inserted.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#40a02b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Deleted</string>
+        <key>scope</key>
+        <string>markup.deleted.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>dotenv left-hand side assignments</string>
+        <key>scope</key>
+        <string>variable.other.env</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>dotenv reference to existing env variable</string>
+        <key>scope</key>
+        <string>string.quoted variable.other.env</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GDScript functions</string>
+        <key>scope</key>
+        <string>support.function.builtin.gdscript</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GDScript constants</string>
+        <key>scope</key>
+        <string>constant.language.gdscript</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Comment keywords</string>
+        <key>scope</key>
+        <string>comment meta.annotation.go</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>go:embed, go:build, etc.</string>
+        <key>scope</key>
+        <string>comment meta.annotation.parameters.go</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Go constants (nil, true, false)</string>
+        <key>scope</key>
+        <string>constant.language.go</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GraphQL variables</string>
+        <key>scope</key>
+        <string>variable.graphql</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GraphQL aliases</string>
+        <key>scope</key>
+        <string>string.unquoted.alias.graphql</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#dd7878</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GraphQL enum members</string>
+        <key>scope</key>
+        <string>constant.character.enum.graphql</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GraphQL field in types</string>
+        <key>scope</key>
+        <string>meta.objectvalues.graphql constant.object.key.graphql string.unquoted.graphql</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#dd7878</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML/XML DOCTYPE as keyword</string>
+        <key>scope</key>
+        <string>keyword.other.doctype, meta.tag.sgml.doctype punctuation.definition.tag, meta.tag.metadata.doctype entity.name.tag, meta.tag.metadata.doctype punctuation.definition.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML/XML-like &lt;tags/&gt;</string>
+        <key>scope</key>
+        <string>entity.name.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Special characters like &amp;amp;</string>
+        <key>scope</key>
+        <string>text.html constant.character.entity, text.html constant.character.entity punctuation, constant.character.entity.xml, constant.character.entity.xml punctuation, constant.character.entity.js.jsx, constant.charactger.entity.js.jsx punctuation, constant.character.entity.tsx, constant.character.entity.tsx punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML/XML tag attribute values</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Components</string>
+        <key>scope</key>
+        <string>support.class.component, support.class.component.jsx, support.class.component.tsx, support.class.component.vue</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Annotations</string>
+        <key>scope</key>
+        <string>punctuation.definition.annotation, storage.type.annotation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Java enums</string>
+        <key>scope</key>
+        <string>constant.other.enum.java</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Java imports</string>
+        <key>scope</key>
+        <string>storage.modifier.import.java</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Javadoc</string>
+        <key>scope</key>
+        <string>comment.block.javadoc.java keyword.other.documentation.javadoc.java</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Exported Variable</string>
+        <key>scope</key>
+        <string>meta.export variable.other.readwrite.js</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JS/TS constants &amp; properties</string>
+        <key>scope</key>
+        <string>variable.other.constant.js, variable.other.constant.ts, variable.other.property.js, variable.other.property.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSDoc; these are mainly params, so styled as such</string>
+        <key>scope</key>
+        <string>variable.other.jsdoc, comment.block.documentation variable.other</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSDoc keywords</string>
+        <key>scope</key>
+        <string>storage.type.class.jsdoc</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>support.type.object.console.js</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Node constants as keywords (module, etc.)</string>
+        <key>scope</key>
+        <string>support.constant.node, support.type.object.module.js</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>implements as keyword</string>
+        <key>scope</key>
+        <string>storage.modifier.implements</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Builtin types</string>
+        <key>scope</key>
+        <string>constant.language.null.js, constant.language.null.ts, constant.language.undefined.js, constant.language.undefined.ts, support.type.builtin.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>variable.parameter.generic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Arrow functions</string>
+        <key>scope</key>
+        <string>keyword.declaration.function.arrow.js, storage.type.function.arrow.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Decorator punctuations (decorators inherit from blue functions, instead of styleguide peach)</string>
+        <key>scope</key>
+        <string>punctuation.decorator.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Extra JS/TS keywords</string>
+        <key>scope</key>
+        <string>keyword.operator.expression.in.js, keyword.operator.expression.in.ts, keyword.operator.expression.infer.ts, keyword.operator.expression.instanceof.js, keyword.operator.expression.instanceof.ts, keyword.operator.expression.is, keyword.operator.expression.keyof.ts, keyword.operator.expression.of.js, keyword.operator.expression.of.ts, keyword.operator.expression.typeof.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Julia macros</string>
+        <key>scope</key>
+        <string>support.function.macro.julia</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Julia language constants (true, false)</string>
+        <key>scope</key>
+        <string>constant.language.julia</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Julia other constants (these seem to be arguments inside arrays)</string>
+        <key>scope</key>
+        <string>constant.other.symbol.julia</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>LaTeX preamble</string>
+        <key>scope</key>
+        <string>text.tex keyword.control.preamble</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>LaTeX be functions</string>
+        <key>scope</key>
+        <string>text.tex support.function.be</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#04a5e5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>LaTeX math</string>
+        <key>scope</key>
+        <string>constant.other.general.math.tex</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#dd7878</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Liquid Builtin Objects &amp; User Defined Variables</string>
+        <key>scope</key>
+        <string>variable.language.liquid</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Lua docstring keywords</string>
+        <key>scope</key>
+        <string>comment.line.double-dash.documentation.lua storage.type.annotation.lua</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Lua docstring variables</string>
+        <key>scope</key>
+        <string>comment.line.double-dash.documentation.lua entity.name.variable.lua, comment.line.double-dash.documentation.lua variable.lua</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.1.markdown punctuation.definition.heading.markdown, heading.1.markdown, heading.1.quarto punctuation.definition.heading.quarto, heading.1.quarto, markup.heading.atx.1.mdx, markup.heading.atx.1.mdx punctuation.definition.heading.mdx, markup.heading.setext.1.markdown, markup.heading.heading-0.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.2.markdown punctuation.definition.heading.markdown, heading.2.markdown, heading.2.quarto punctuation.definition.heading.quarto, heading.2.quarto, markup.heading.atx.2.mdx, markup.heading.atx.2.mdx punctuation.definition.heading.mdx, markup.heading.setext.2.markdown, markup.heading.heading-1.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.3.markdown punctuation.definition.heading.markdown, heading.3.markdown, heading.3.quarto punctuation.definition.heading.quarto, heading.3.quarto, markup.heading.atx.3.mdx, markup.heading.atx.3.mdx punctuation.definition.heading.mdx, markup.heading.heading-2.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.4.markdown punctuation.definition.heading.markdown, heading.4.markdown, heading.4.quarto punctuation.definition.heading.quarto, heading.4.quarto, markup.heading.atx.4.mdx, markup.heading.atx.4.mdx punctuation.definition.heading.mdx, markup.heading.heading-3.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#40a02b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.5.markdown punctuation.definition.heading.markdown, heading.5.markdown, heading.5.quarto punctuation.definition.heading.quarto, heading.5.quarto, markup.heading.atx.5.mdx, markup.heading.atx.5.mdx punctuation.definition.heading.mdx, markup.heading.heading-4.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#209fb5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.6.markdown punctuation.definition.heading.markdown, heading.6.markdown, heading.6.quarto punctuation.definition.heading.quarto, heading.6.quarto, markup.heading.atx.6.mdx, markup.heading.atx.6.mdx punctuation.definition.heading.mdx, markup.heading.heading-5.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7287fd</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.bold</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.italic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.strikethrough</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#6c6f85</string>
+          <key>fontStyle</key>
+          <string>strikethrough</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown auto links</string>
+        <key>scope</key>
+        <string>punctuation.definition.link, markup.underline.link</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown links</string>
+        <key>scope</key>
+        <string>text.html.markdown punctuation.definition.link.title, text.html.quarto punctuation.definition.link.title, string.other.link.title.markdown, string.other.link.title.quarto, markup.link, punctuation.definition.constant.markdown, punctuation.definition.constant.quarto, constant.other.reference.link.markdown, constant.other.reference.link.quarto, markup.substitution.attribute-reference</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7287fd</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown code spans</string>
+        <key>scope</key>
+        <string>punctuation.definition.raw.markdown, punctuation.definition.raw.quarto, markup.inline.raw.string.markdown, markup.inline.raw.string.quarto, markup.raw.block.markdown, markup.raw.block.quarto</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#40a02b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown triple backtick language identifier</string>
+        <key>scope</key>
+        <string>fenced_code.block.language</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#04a5e5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown triple backticks</string>
+        <key>scope</key>
+        <string>markup.fenced_code.block punctuation.definition, markup.raw support.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7c7f93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown quotes</string>
+        <key>scope</key>
+        <string>markup.quote, punctuation.definition.quote.begin</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown separators</string>
+        <key>scope</key>
+        <string>meta.separator.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown list bullets</string>
+        <key>scope</key>
+        <string>punctuation.definition.list.begin.markdown, punctuation.definition.list.begin.quarto, markup.list.bullet</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Quarto headings</string>
+        <key>scope</key>
+        <string>markup.heading.quarto</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Nix attribute names</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name.multipart.nix, entity.other.attribute-name.single.nix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Nix parameter names</string>
+        <key>scope</key>
+        <string>variable.parameter.name.nix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Nix interpolated parameter names</string>
+        <key>scope</key>
+        <string>meta.embedded variable.parameter.name.nix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7287fd</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Nix paths</string>
+        <key>scope</key>
+        <string>string.unquoted.path.nix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHP Attributes</string>
+        <key>scope</key>
+        <string>support.attribute.builtin, meta.attribute.php</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHP Parameters (needed for the leading dollar sign)</string>
+        <key>scope</key>
+        <string>meta.function.parameters.php punctuation.definition.variable.php</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHP Constants (null, __FILE__, etc.)</string>
+        <key>scope</key>
+        <string>constant.language.php</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHP functions</string>
+        <key>scope</key>
+        <string>text.html.php support.function</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#04a5e5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHPdoc keywords</string>
+        <key>scope</key>
+        <string>keyword.other.phpdoc.php</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python argument functions reset to text, otherwise they inherit blue from function-call</string>
+        <key>scope</key>
+        <string>support.variable.magic.python, meta.function-call.arguments.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python double underscore functions</string>
+        <key>scope</key>
+        <string>support.function.magic.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#04a5e5</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python `self` keyword</string>
+        <key>scope</key>
+        <string>variable.parameter.function.language.special.self.python, variable.language.special.self.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python keyword flow/logical (for ... in)</string>
+        <key>scope</key>
+        <string>keyword.control.flow.python, keyword.operator.logical.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python storage type</string>
+        <key>scope</key>
+        <string>storage.type.function.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python function support</string>
+        <key>scope</key>
+        <string>support.token.decorator.python, meta.function.decorator.identifier.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#04a5e5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python function calls</string>
+        <key>scope</key>
+        <string>meta.function-call.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python function decorators</string>
+        <key>scope</key>
+        <string>entity.name.function.decorator.python, punctuation.definition.decorator.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python placeholder reset to normal string</string>
+        <key>scope</key>
+        <string>constant.character.format.placeholder.other.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python exception &amp; builtins such as exit()</string>
+        <key>scope</key>
+        <string>support.type.exception.python, support.function.builtin.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>entity.name.type</string>
+        <key>scope</key>
+        <string>support.type.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python constants (True/False)</string>
+        <key>scope</key>
+        <string>constant.language.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Arguments accessed later in the function body</string>
+        <key>scope</key>
+        <string>meta.indexed-name.python, meta.item-access.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python f-strings/binary/unicode storage types</string>
+        <key>scope</key>
+        <string>storage.type.string.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#40a02b</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python type hints</string>
+        <key>scope</key>
+        <string>meta.function.parameters.python</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex string begin/end in JS/TS</string>
+        <key>scope</key>
+        <string>string.regexp punctuation.definition.string.begin, string.regexp punctuation.definition.string.end</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex anchors (^, $)</string>
+        <key>scope</key>
+        <string>keyword.control.anchor.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex regular string match</string>
+        <key>scope</key>
+        <string>string.regexp.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex group parenthesis &amp; backreference (\1, \2, \3, ...)</string>
+        <key>scope</key>
+        <string>punctuation.definition.group.regexp, keyword.other.back-reference.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#40a02b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex character class []</string>
+        <key>scope</key>
+        <string>punctuation.definition.character-class.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex character classes (\d, \w, \s)</string>
+        <key>scope</key>
+        <string>constant.other.character-class.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex range</string>
+        <key>scope</key>
+        <string>constant.other.character-class.range.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#dc8a78</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex quantifier</string>
+        <key>scope</key>
+        <string>keyword.operator.quantifier.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex constant/numeric</string>
+        <key>scope</key>
+        <string>constant.character.numeric.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex lookaheads, negative lookaheads, lookbehinds, negative lookbehinds</string>
+        <key>scope</key>
+        <string>punctuation.definition.group.no-capture.regexp, meta.assertion.look-ahead.regexp, meta.assertion.negative-look-ahead.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust attribute</string>
+        <key>scope</key>
+        <string>meta.annotation.rust, meta.annotation.rust punctuation, meta.attribute.rust, punctuation.definition.attribute.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust attribute strings</string>
+        <key>scope</key>
+        <string>meta.attribute.rust string.quoted.double.rust, meta.attribute.rust string.quoted.single.char.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust keyword</string>
+        <key>scope</key>
+        <string>entity.name.function.macro.rules.rust, storage.type.module.rust, storage.modifier.rust, storage.type.struct.rust, storage.type.enum.rust, storage.type.trait.rust, storage.type.union.rust, storage.type.impl.rust, storage.type.rust, storage.type.function.rust, storage.type.type.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust u/i32, u/i64, etc.</string>
+        <key>scope</key>
+        <string>entity.name.type.numeric.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust generic</string>
+        <key>scope</key>
+        <string>meta.generic.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust impl</string>
+        <key>scope</key>
+        <string>entity.name.impl.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust module</string>
+        <key>scope</key>
+        <string>entity.name.module.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust trait</string>
+        <key>scope</key>
+        <string>entity.name.trait.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust struct</string>
+        <key>scope</key>
+        <string>storage.type.source.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust union</string>
+        <key>scope</key>
+        <string>entity.name.union.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust enum member</string>
+        <key>scope</key>
+        <string>meta.enum.rust storage.type.source.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust macro</string>
+        <key>scope</key>
+        <string>support.macro.rust, meta.macro.rust support.function.rust, entity.name.function.macro.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust lifetime</string>
+        <key>scope</key>
+        <string>storage.modifier.lifetime.rust, entity.name.type.lifetime</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust string formatting</string>
+        <key>scope</key>
+        <string>string.quoted.double.rust constant.other.placeholder.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust return type generic</string>
+        <key>scope</key>
+        <string>meta.function.return-type.rust meta.generic.rust storage.type.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust functions</string>
+        <key>scope</key>
+        <string>meta.function.call.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust angle brackets</string>
+        <key>scope</key>
+        <string>punctuation.brackets.angle.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#04a5e5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust constants</string>
+        <key>scope</key>
+        <string>constant.other.caps.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust function parameters</string>
+        <key>scope</key>
+        <string>meta.function.definition.rust variable.other.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#e64553</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust closure variables</string>
+        <key>scope</key>
+        <string>meta.function.call.rust variable.other.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust self</string>
+        <key>scope</key>
+        <string>variable.language.self.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust metavariable names</string>
+        <key>scope</key>
+        <string>variable.other.metavariable.name.rust, meta.macro.metavariable.rust keyword.operator.macro.dollar.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell shebang</string>
+        <key>scope</key>
+        <string>comment.line.shebang, comment.line.shebang punctuation.definition.comment, comment.line.shebang, punctuation.definition.comment.shebang.shell, meta.shebang.shell</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell shebang command</string>
+        <key>scope</key>
+        <string>comment.line.shebang constant.language</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell interpolated command</string>
+        <key>scope</key>
+        <string>meta.function-call.arguments.shell punctuation.definition.variable.shell, meta.function-call.arguments.shell punctuation.section.interpolation, meta.function-call.arguments.shell punctuation.definition.variable.shell, meta.function-call.arguments.shell punctuation.section.interpolation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell interpolated command variable</string>
+        <key>scope</key>
+        <string>meta.string meta.interpolation.parameter.shell variable.other.readwrite</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>source.shell punctuation.section.interpolation, punctuation.definition.evaluation.backticks.shell</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell EOF</string>
+        <key>scope</key>
+        <string>entity.name.tag.heredoc.shell</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell quoted variable</string>
+        <key>scope</key>
+        <string>string.quoted.double.shell variable.other.normal.shell</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#4c4f69</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.typst</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON Keys</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON key surrounding quotes</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key punctuation.definition.string.begin, source.json meta.mapping.key punctuation.definition.string.end</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7c7f93</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.synopsis.man, markup.heading.title.man, markup.heading.other.man, markup.heading.env.man</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8839ef</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.commands.man</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.env.man</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ea76cb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Man page options</string>
+        <key>scope</key>
+        <string>entity.name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#179299</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.1.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#d20f39</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.2.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fe640b</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#df8e1d</string>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/bat/.config/bat/themes/Catppuccin Mocha.tmTheme
+++ b/bat/.config/bat/themes/Catppuccin Mocha.tmTheme
@@ -1,0 +1,2112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>Catppuccin Mocha</string>
+    <key>semanticClass</key>
+    <string>theme.dark.catppuccin-mocha</string>
+    <key>uuid</key>
+    <string>627ce890-fabb-4d39-9819-7be71f4bdca7</string>
+    <key>author</key>
+    <string>Catppuccin Org</string>
+    <key>colorSpaceName</key>
+    <string>sRGB</string>
+    <key>settings</key>
+    <array>
+      <dict>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#1e1e2e</string>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+          <key>caret</key>
+          <string>#f5e0dc</string>
+          <key>lineHighlight</key>
+          <string>#313244</string>
+          <key>misspelling</key>
+          <string>#f38ba8</string>
+          <key>accent</key>
+          <string>#cba6f7</string>
+          <key>selection</key>
+          <string>#9399b240</string>
+          <key>activeGuide</key>
+          <string>#45475a</string>
+          <key>findHighlight</key>
+          <string>#3e5767</string>
+          <key>gutterForeground</key>
+          <string>#7f849c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Basic text &amp; variable names (incl. leading punctuation)</string>
+        <key>scope</key>
+        <string>text, source, variable.other.readwrite, punctuation.definition.variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Parentheses, Brackets, Braces</string>
+        <key>scope</key>
+        <string>punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9399b2</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Comments</string>
+        <key>scope</key>
+        <string>comment, punctuation.definition.comment</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9399b2</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>string, punctuation.definition.string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6e3a1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>constant.character.escape</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Booleans, constants, numbers</string>
+        <key>scope</key>
+        <string>constant.numeric, variable.other.constant, entity.name.constant, constant.language.boolean, constant.language.false, constant.language.true, keyword.other.unit.user-defined, keyword.other.unit.suffix.floating-point</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>keyword, keyword.operator.word, keyword.operator.new, variable.language.super, support.type.primitive, storage.type, storage.modifier, punctuation.definition.keyword</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.tag.documentation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Punctuation</string>
+        <key>scope</key>
+        <string>keyword.operator, punctuation.accessor, punctuation.definition.generic, meta.function.closure punctuation.section.parameters, punctuation.definition.tag, punctuation.separator.key-value</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.function, meta.function-call.method, support.function, support.function.misc, variable.function</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Classes</string>
+        <key>scope</key>
+        <string>entity.name.class, entity.other.inherited-class, support.class, meta.function-call.constructor, entity.name.struct</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Enum</string>
+        <key>scope</key>
+        <string>entity.name.enum</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Enum member</string>
+        <key>scope</key>
+        <string>meta.enum variable.other.readwrite, variable.other.enummember</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Object properties</string>
+        <key>scope</key>
+        <string>meta.property.object</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Types</string>
+        <key>scope</key>
+        <string>meta.type, meta.type-alias, support.type, entity.name.type</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Decorators</string>
+        <key>scope</key>
+        <string>meta.annotation variable.function, meta.annotation variable.annotation.function, meta.annotation punctuation.definition.annotation, meta.decorator, punctuation.decorator</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>variable.parameter, meta.function.parameters</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Built-ins</string>
+        <key>scope</key>
+        <string>constant.language, support.function.builtin</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.other.attribute-name.documentation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Preprocessor directives</string>
+        <key>scope</key>
+        <string>keyword.control.directive, punctuation.definition.directive</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Type parameters</string>
+        <key>scope</key>
+        <string>punctuation.definition.typeparameters</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89dceb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Namespaces</string>
+        <key>scope</key>
+        <string>entity.name.namespace</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Property names (left hand assignments in json/yaml/css)</string>
+        <key>scope</key>
+        <string>support.type.property-name.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>This/Self keyword</string>
+        <key>scope</key>
+        <string>variable.language.this, variable.language.this punctuation.definition.variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Object properties</string>
+        <key>scope</key>
+        <string>variable.object.property</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>String template interpolation</string>
+        <key>scope</key>
+        <string>string.template variable, string variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>`new` as bold</string>
+        <key>scope</key>
+        <string>keyword.operator.new</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C++ extern keyword</string>
+        <key>scope</key>
+        <string>storage.modifier.specifier.extern.cpp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C++ scope resolution</string>
+        <key>scope</key>
+        <string>entity.name.scope-resolution.template.call.cpp, entity.name.scope-resolution.parameter.cpp, entity.name.scope-resolution.cpp, entity.name.scope-resolution.function.definition.cpp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C++ doc keywords</string>
+        <key>scope</key>
+        <string>storage.type.class.doxygen</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C++ operators</string>
+        <key>scope</key>
+        <string>storage.modifier.reference.cpp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C# Interpolated Strings</string>
+        <key>scope</key>
+        <string>meta.interpolation.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>C# xml-style docs</string>
+        <key>scope</key>
+        <string>comment.block.documentation.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Classes, reflecting the className color in JSX</string>
+        <key>scope</key>
+        <string>source.css entity.other.attribute-name.class.css, entity.other.attribute-name.parent-selector.css punctuation.definition.entity.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Operators</string>
+        <key>scope</key>
+        <string>punctuation.separator.operator.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Pseudo classes</string>
+        <key>scope</key>
+        <string>source.css entity.other.attribute-name.pseudo-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>source.css constant.other.unicode-range</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>source.css variable.parameter.url</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6e3a1</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS vendored property names</string>
+        <key>scope</key>
+        <string>support.type.vendored.property-name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89dceb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Less/SCSS right-hand variables (@/$-prefixed)</string>
+        <key>scope</key>
+        <string>source.css meta.property-value variable, source.css meta.property-value variable.other.less, source.css meta.property-value variable.other.less punctuation.definition.variable.less, meta.definition.variable.scss</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS variables (--prefixed)</string>
+        <key>scope</key>
+        <string>source.css meta.property-list variable, meta.property-list variable.other.less, meta.property-list variable.other.less punctuation.definition.variable.less</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Percentage values, styled the same as numbers</string>
+        <key>scope</key>
+        <string>keyword.other.unit.percentage.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>CSS Attribute selectors, styled the same as strings</string>
+        <key>scope</key>
+        <string>source.css meta.attribute-selector</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6e3a1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON/YAML keys, other left-hand assignments</string>
+        <key>scope</key>
+        <string>keyword.other.definition.ini, punctuation.support.type.property-name.json, support.type.property-name.json, punctuation.support.type.property-name.toml, support.type.property-name.toml, entity.name.tag.yaml, punctuation.support.type.property-name.yaml, support.type.property-name.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON/YAML constants</string>
+        <key>scope</key>
+        <string>constant.language.json, constant.language.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>YAML anchors</string>
+        <key>scope</key>
+        <string>entity.name.type.anchor.yaml, variable.other.alias.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>TOML tables / ini groups</string>
+        <key>scope</key>
+        <string>support.type.property-name.table, entity.name.section.group-title.ini</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>TOML dates</string>
+        <key>scope</key>
+        <string>constant.other.time.datetime.offset.toml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>YAML anchor puctuation</string>
+        <key>scope</key>
+        <string>punctuation.definition.anchor.yaml, punctuation.definition.alias.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>YAML triple dashes</string>
+        <key>scope</key>
+        <string>entity.other.document.begin.yaml</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup Diff</string>
+        <key>scope</key>
+        <string>markup.changed.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff</string>
+        <key>scope</key>
+        <string>meta.diff.header.from-file, meta.diff.header.to-file, punctuation.definition.from-file.diff, punctuation.definition.to-file.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Inserted</string>
+        <key>scope</key>
+        <string>markup.inserted.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6e3a1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Diff Deleted</string>
+        <key>scope</key>
+        <string>markup.deleted.diff</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>dotenv left-hand side assignments</string>
+        <key>scope</key>
+        <string>variable.other.env</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>dotenv reference to existing env variable</string>
+        <key>scope</key>
+        <string>string.quoted variable.other.env</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GDScript functions</string>
+        <key>scope</key>
+        <string>support.function.builtin.gdscript</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GDScript constants</string>
+        <key>scope</key>
+        <string>constant.language.gdscript</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Comment keywords</string>
+        <key>scope</key>
+        <string>comment meta.annotation.go</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>go:embed, go:build, etc.</string>
+        <key>scope</key>
+        <string>comment meta.annotation.parameters.go</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Go constants (nil, true, false)</string>
+        <key>scope</key>
+        <string>constant.language.go</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GraphQL variables</string>
+        <key>scope</key>
+        <string>variable.graphql</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GraphQL aliases</string>
+        <key>scope</key>
+        <string>string.unquoted.alias.graphql</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f2cdcd</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GraphQL enum members</string>
+        <key>scope</key>
+        <string>constant.character.enum.graphql</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>GraphQL field in types</string>
+        <key>scope</key>
+        <string>meta.objectvalues.graphql constant.object.key.graphql string.unquoted.graphql</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f2cdcd</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML/XML DOCTYPE as keyword</string>
+        <key>scope</key>
+        <string>keyword.other.doctype, meta.tag.sgml.doctype punctuation.definition.tag, meta.tag.metadata.doctype entity.name.tag, meta.tag.metadata.doctype punctuation.definition.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML/XML-like &lt;tags/&gt;</string>
+        <key>scope</key>
+        <string>entity.name.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Special characters like &amp;amp;</string>
+        <key>scope</key>
+        <string>text.html constant.character.entity, text.html constant.character.entity punctuation, constant.character.entity.xml, constant.character.entity.xml punctuation, constant.character.entity.js.jsx, constant.charactger.entity.js.jsx punctuation, constant.character.entity.tsx, constant.character.entity.tsx punctuation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>HTML/XML tag attribute values</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Components</string>
+        <key>scope</key>
+        <string>support.class.component, support.class.component.jsx, support.class.component.tsx, support.class.component.vue</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Annotations</string>
+        <key>scope</key>
+        <string>punctuation.definition.annotation, storage.type.annotation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Java enums</string>
+        <key>scope</key>
+        <string>constant.other.enum.java</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Java imports</string>
+        <key>scope</key>
+        <string>storage.modifier.import.java</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Javadoc</string>
+        <key>scope</key>
+        <string>comment.block.javadoc.java keyword.other.documentation.javadoc.java</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Exported Variable</string>
+        <key>scope</key>
+        <string>meta.export variable.other.readwrite.js</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JS/TS constants &amp; properties</string>
+        <key>scope</key>
+        <string>variable.other.constant.js, variable.other.constant.ts, variable.other.property.js, variable.other.property.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSDoc; these are mainly params, so styled as such</string>
+        <key>scope</key>
+        <string>variable.other.jsdoc, comment.block.documentation variable.other</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSDoc keywords</string>
+        <key>scope</key>
+        <string>storage.type.class.jsdoc</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>support.type.object.console.js</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Node constants as keywords (module, etc.)</string>
+        <key>scope</key>
+        <string>support.constant.node, support.type.object.module.js</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>implements as keyword</string>
+        <key>scope</key>
+        <string>storage.modifier.implements</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Builtin types</string>
+        <key>scope</key>
+        <string>constant.language.null.js, constant.language.null.ts, constant.language.undefined.js, constant.language.undefined.ts, support.type.builtin.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>variable.parameter.generic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Arrow functions</string>
+        <key>scope</key>
+        <string>keyword.declaration.function.arrow.js, storage.type.function.arrow.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Decorator punctuations (decorators inherit from blue functions, instead of styleguide peach)</string>
+        <key>scope</key>
+        <string>punctuation.decorator.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Extra JS/TS keywords</string>
+        <key>scope</key>
+        <string>keyword.operator.expression.in.js, keyword.operator.expression.in.ts, keyword.operator.expression.infer.ts, keyword.operator.expression.instanceof.js, keyword.operator.expression.instanceof.ts, keyword.operator.expression.is, keyword.operator.expression.keyof.ts, keyword.operator.expression.of.js, keyword.operator.expression.of.ts, keyword.operator.expression.typeof.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Julia macros</string>
+        <key>scope</key>
+        <string>support.function.macro.julia</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Julia language constants (true, false)</string>
+        <key>scope</key>
+        <string>constant.language.julia</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Julia other constants (these seem to be arguments inside arrays)</string>
+        <key>scope</key>
+        <string>constant.other.symbol.julia</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>LaTeX preamble</string>
+        <key>scope</key>
+        <string>text.tex keyword.control.preamble</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>LaTeX be functions</string>
+        <key>scope</key>
+        <string>text.tex support.function.be</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89dceb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>LaTeX math</string>
+        <key>scope</key>
+        <string>constant.other.general.math.tex</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f2cdcd</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Liquid Builtin Objects &amp; User Defined Variables</string>
+        <key>scope</key>
+        <string>variable.language.liquid</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Lua docstring keywords</string>
+        <key>scope</key>
+        <string>comment.line.double-dash.documentation.lua storage.type.annotation.lua</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Lua docstring variables</string>
+        <key>scope</key>
+        <string>comment.line.double-dash.documentation.lua entity.name.variable.lua, comment.line.double-dash.documentation.lua variable.lua</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.1.markdown punctuation.definition.heading.markdown, heading.1.markdown, heading.1.quarto punctuation.definition.heading.quarto, heading.1.quarto, markup.heading.atx.1.mdx, markup.heading.atx.1.mdx punctuation.definition.heading.mdx, markup.heading.setext.1.markdown, markup.heading.heading-0.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.2.markdown punctuation.definition.heading.markdown, heading.2.markdown, heading.2.quarto punctuation.definition.heading.quarto, heading.2.quarto, markup.heading.atx.2.mdx, markup.heading.atx.2.mdx punctuation.definition.heading.mdx, markup.heading.setext.2.markdown, markup.heading.heading-1.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.3.markdown punctuation.definition.heading.markdown, heading.3.markdown, heading.3.quarto punctuation.definition.heading.quarto, heading.3.quarto, markup.heading.atx.3.mdx, markup.heading.atx.3.mdx punctuation.definition.heading.mdx, markup.heading.heading-2.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.4.markdown punctuation.definition.heading.markdown, heading.4.markdown, heading.4.quarto punctuation.definition.heading.quarto, heading.4.quarto, markup.heading.atx.4.mdx, markup.heading.atx.4.mdx punctuation.definition.heading.mdx, markup.heading.heading-3.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6e3a1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.5.markdown punctuation.definition.heading.markdown, heading.5.markdown, heading.5.quarto punctuation.definition.heading.quarto, heading.5.quarto, markup.heading.atx.5.mdx, markup.heading.atx.5.mdx punctuation.definition.heading.mdx, markup.heading.heading-4.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#74c7ec</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>heading.6.markdown punctuation.definition.heading.markdown, heading.6.markdown, heading.6.quarto punctuation.definition.heading.quarto, heading.6.quarto, markup.heading.atx.6.mdx, markup.heading.atx.6.mdx punctuation.definition.heading.mdx, markup.heading.heading-5.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b4befe</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.bold</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.italic</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.strikethrough</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6adc8</string>
+          <key>fontStyle</key>
+          <string>strikethrough</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown auto links</string>
+        <key>scope</key>
+        <string>punctuation.definition.link, markup.underline.link</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown links</string>
+        <key>scope</key>
+        <string>text.html.markdown punctuation.definition.link.title, text.html.quarto punctuation.definition.link.title, string.other.link.title.markdown, string.other.link.title.quarto, markup.link, punctuation.definition.constant.markdown, punctuation.definition.constant.quarto, constant.other.reference.link.markdown, constant.other.reference.link.quarto, markup.substitution.attribute-reference</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b4befe</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown code spans</string>
+        <key>scope</key>
+        <string>punctuation.definition.raw.markdown, punctuation.definition.raw.quarto, markup.inline.raw.string.markdown, markup.inline.raw.string.quarto, markup.raw.block.markdown, markup.raw.block.quarto</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6e3a1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown triple backtick language identifier</string>
+        <key>scope</key>
+        <string>fenced_code.block.language</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89dceb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown triple backticks</string>
+        <key>scope</key>
+        <string>markup.fenced_code.block punctuation.definition, markup.raw support.asciidoc</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9399b2</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown quotes</string>
+        <key>scope</key>
+        <string>markup.quote, punctuation.definition.quote.begin</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown separators</string>
+        <key>scope</key>
+        <string>meta.separator.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markdown list bullets</string>
+        <key>scope</key>
+        <string>punctuation.definition.list.begin.markdown, punctuation.definition.list.begin.quarto, markup.list.bullet</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Quarto headings</string>
+        <key>scope</key>
+        <string>markup.heading.quarto</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>bold</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Nix attribute names</string>
+        <key>scope</key>
+        <string>entity.other.attribute-name.multipart.nix, entity.other.attribute-name.single.nix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Nix parameter names</string>
+        <key>scope</key>
+        <string>variable.parameter.name.nix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Nix interpolated parameter names</string>
+        <key>scope</key>
+        <string>meta.embedded variable.parameter.name.nix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#b4befe</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Nix paths</string>
+        <key>scope</key>
+        <string>string.unquoted.path.nix</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHP Attributes</string>
+        <key>scope</key>
+        <string>support.attribute.builtin, meta.attribute.php</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHP Parameters (needed for the leading dollar sign)</string>
+        <key>scope</key>
+        <string>meta.function.parameters.php punctuation.definition.variable.php</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHP Constants (null, __FILE__, etc.)</string>
+        <key>scope</key>
+        <string>constant.language.php</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHP functions</string>
+        <key>scope</key>
+        <string>text.html.php support.function</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89dceb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>PHPdoc keywords</string>
+        <key>scope</key>
+        <string>keyword.other.phpdoc.php</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python argument functions reset to text, otherwise they inherit blue from function-call</string>
+        <key>scope</key>
+        <string>support.variable.magic.python, meta.function-call.arguments.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python double underscore functions</string>
+        <key>scope</key>
+        <string>support.function.magic.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89dceb</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python `self` keyword</string>
+        <key>scope</key>
+        <string>variable.parameter.function.language.special.self.python, variable.language.special.self.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python keyword flow/logical (for ... in)</string>
+        <key>scope</key>
+        <string>keyword.control.flow.python, keyword.operator.logical.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python storage type</string>
+        <key>scope</key>
+        <string>storage.type.function.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python function support</string>
+        <key>scope</key>
+        <string>support.token.decorator.python, meta.function.decorator.identifier.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89dceb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python function calls</string>
+        <key>scope</key>
+        <string>meta.function-call.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python function decorators</string>
+        <key>scope</key>
+        <string>entity.name.function.decorator.python, punctuation.definition.decorator.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python placeholder reset to normal string</string>
+        <key>scope</key>
+        <string>constant.character.format.placeholder.other.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python exception &amp; builtins such as exit()</string>
+        <key>scope</key>
+        <string>support.type.exception.python, support.function.builtin.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>entity.name.type</string>
+        <key>scope</key>
+        <string>support.type.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>python constants (True/False)</string>
+        <key>scope</key>
+        <string>constant.language.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Arguments accessed later in the function body</string>
+        <key>scope</key>
+        <string>meta.indexed-name.python, meta.item-access.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python f-strings/binary/unicode storage types</string>
+        <key>scope</key>
+        <string>storage.type.string.python</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6e3a1</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Python type hints</string>
+        <key>scope</key>
+        <string>meta.function.parameters.python</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex string begin/end in JS/TS</string>
+        <key>scope</key>
+        <string>string.regexp punctuation.definition.string.begin, string.regexp punctuation.definition.string.end</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex anchors (^, $)</string>
+        <key>scope</key>
+        <string>keyword.control.anchor.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex regular string match</string>
+        <key>scope</key>
+        <string>string.regexp.ts</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex group parenthesis &amp; backreference (\1, \2, \3, ...)</string>
+        <key>scope</key>
+        <string>punctuation.definition.group.regexp, keyword.other.back-reference.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#a6e3a1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex character class []</string>
+        <key>scope</key>
+        <string>punctuation.definition.character-class.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex character classes (\d, \w, \s)</string>
+        <key>scope</key>
+        <string>constant.other.character-class.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex range</string>
+        <key>scope</key>
+        <string>constant.other.character-class.range.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5e0dc</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex quantifier</string>
+        <key>scope</key>
+        <string>keyword.operator.quantifier.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex constant/numeric</string>
+        <key>scope</key>
+        <string>constant.character.numeric.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Regex lookaheads, negative lookaheads, lookbehinds, negative lookbehinds</string>
+        <key>scope</key>
+        <string>punctuation.definition.group.no-capture.regexp, meta.assertion.look-ahead.regexp, meta.assertion.negative-look-ahead.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust attribute</string>
+        <key>scope</key>
+        <string>meta.annotation.rust, meta.annotation.rust punctuation, meta.attribute.rust, punctuation.definition.attribute.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust attribute strings</string>
+        <key>scope</key>
+        <string>meta.attribute.rust string.quoted.double.rust, meta.attribute.rust string.quoted.single.char.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust keyword</string>
+        <key>scope</key>
+        <string>entity.name.function.macro.rules.rust, storage.type.module.rust, storage.modifier.rust, storage.type.struct.rust, storage.type.enum.rust, storage.type.trait.rust, storage.type.union.rust, storage.type.impl.rust, storage.type.rust, storage.type.function.rust, storage.type.type.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust u/i32, u/i64, etc.</string>
+        <key>scope</key>
+        <string>entity.name.type.numeric.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+          <key>fontStyle</key>
+          <string/>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust generic</string>
+        <key>scope</key>
+        <string>meta.generic.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust impl</string>
+        <key>scope</key>
+        <string>entity.name.impl.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust module</string>
+        <key>scope</key>
+        <string>entity.name.module.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust trait</string>
+        <key>scope</key>
+        <string>entity.name.trait.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust struct</string>
+        <key>scope</key>
+        <string>storage.type.source.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust union</string>
+        <key>scope</key>
+        <string>entity.name.union.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust enum member</string>
+        <key>scope</key>
+        <string>meta.enum.rust storage.type.source.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust macro</string>
+        <key>scope</key>
+        <string>support.macro.rust, meta.macro.rust support.function.rust, entity.name.function.macro.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust lifetime</string>
+        <key>scope</key>
+        <string>storage.modifier.lifetime.rust, entity.name.type.lifetime</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust string formatting</string>
+        <key>scope</key>
+        <string>string.quoted.double.rust constant.other.placeholder.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust return type generic</string>
+        <key>scope</key>
+        <string>meta.function.return-type.rust meta.generic.rust storage.type.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust functions</string>
+        <key>scope</key>
+        <string>meta.function.call.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust angle brackets</string>
+        <key>scope</key>
+        <string>punctuation.brackets.angle.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89dceb</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust constants</string>
+        <key>scope</key>
+        <string>constant.other.caps.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust function parameters</string>
+        <key>scope</key>
+        <string>meta.function.definition.rust variable.other.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#eba0ac</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust closure variables</string>
+        <key>scope</key>
+        <string>meta.function.call.rust variable.other.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust self</string>
+        <key>scope</key>
+        <string>variable.language.self.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Rust metavariable names</string>
+        <key>scope</key>
+        <string>variable.other.metavariable.name.rust, meta.macro.metavariable.rust keyword.operator.macro.dollar.rust</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell shebang</string>
+        <key>scope</key>
+        <string>comment.line.shebang, comment.line.shebang punctuation.definition.comment, comment.line.shebang, punctuation.definition.comment.shebang.shell, meta.shebang.shell</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell shebang command</string>
+        <key>scope</key>
+        <string>comment.line.shebang constant.language</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell interpolated command</string>
+        <key>scope</key>
+        <string>meta.function-call.arguments.shell punctuation.definition.variable.shell, meta.function-call.arguments.shell punctuation.section.interpolation, meta.function-call.arguments.shell punctuation.definition.variable.shell, meta.function-call.arguments.shell punctuation.section.interpolation</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell interpolated command variable</string>
+        <key>scope</key>
+        <string>meta.string meta.interpolation.parameter.shell variable.other.readwrite</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>source.shell punctuation.section.interpolation, punctuation.definition.evaluation.backticks.shell</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell EOF</string>
+        <key>scope</key>
+        <string>entity.name.tag.heredoc.shell</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Shell quoted variable</string>
+        <key>scope</key>
+        <string>string.quoted.double.shell variable.other.normal.shell</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cdd6f4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.typst</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON Keys</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON key surrounding quotes</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key punctuation.definition.string.begin, source.json meta.mapping.key punctuation.definition.string.end</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9399b2</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.synopsis.man, markup.heading.title.man, markup.heading.other.man, markup.heading.env.man</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cba6f7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.commands.man</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.env.man</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f5c2e7</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Man page options</string>
+        <key>scope</key>
+        <string>entity.name</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#94e2d5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.1.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f38ba8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.2.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#fab387</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>markup.heading.markdown</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f9e2af</string>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/install.sh
+++ b/install.sh
@@ -83,12 +83,12 @@ install_rail() {
 install_tier_packages() {
   case "$1:$OS" in
   core:Darwin)
-    brew_install stow git gh git-delta uv starship fzf tmux node
+    brew_install stow git gh git-delta uv starship fzf tmux node bat
     install_zsh_plugins
     install_rail
     ;;
   core:Linux)
-    apt_install stow git gh git-delta curl zsh fzf nodejs npm
+    apt_install stow git gh git-delta curl zsh fzf nodejs npm bat
     # uv and starship are not packaged in apt; use the official installers.
     command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
     command -v starship >/dev/null 2>&1 || curl -sS https://starship.rs/install.sh | sh -s -- -y
@@ -169,6 +169,14 @@ done
 # Render the theme so every consumer has colors from the first shell.
 if [ -x "$HOME/.local/bin/theme" ]; then
   "$HOME/.local/bin/theme" apply
+fi
+
+# Rebuild bat's theme cache now that the vendored Catppuccin tmThemes are
+# stowed in; apt names the binary batcat (see zsh/aliases.zsh for the alias).
+if command -v bat >/dev/null 2>&1; then
+  bat cache --build
+elif command -v batcat >/dev/null 2>&1; then
+  batcat cache --build
 fi
 
 # The commit gate for working on this repo (see README: Development).

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,9 @@ install_tier_packages() {
   mac:Darwin)
     # Hammerspoon is a cask; it hosts the pokemon mascot (see hammerspoon/).
     brew list --cask hammerspoon >/dev/null 2>&1 || brew install --cask hammerspoon
+    # sketchybar itself is mac-only; the plugins under sketchybar/ shell out
+    # to macOS-only tools (pmset, ipconfig) regardless.
+    brew_install sketchybar
     ;;
   *)
     echo "error: unknown tier for $OS: $1" >&2

--- a/sketchybar/.config/sketchybar/colors.sh
+++ b/sketchybar/.config/sketchybar/colors.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+# Colors are never hardcoded here — they're rendered by `theme` from tokens
+# (see theme/.config/theme/templates/sketchybar-colors.sh.tmpl). Every
+# plugin and sketchybarrc itself source this file to pick them up.
+source "${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/generated/sketchybar-colors.sh"

--- a/sketchybar/.config/sketchybar/plugins/aerospace.sh
+++ b/sketchybar/.config/sketchybar/plugins/aerospace.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env zsh
+# Aerospace workspace indicator plugin
+# Updates workspace highlighting when workspace changes, colors update, or tmux bell fires
+#
+# States:
+# - Active (focused): accent color (follows the pokemon)
+# - Bell (code workspace with tmux bell): notify color (follows the pokemon)
+# - Inactive: dim
+
+source "$HOME/.config/sketchybar/colors.sh"
+
+# SketchyBar passes FOCUSED_WORKSPACE on aerospace_workspace_change.
+# Cache it so color/bell refreshes don't need to shell out to AeroSpace.
+FOCUSED_CACHE="$HOME/.cache/aerospace-focused-workspace"
+if [[ -n "${FOCUSED_WORKSPACE:-}" ]]; then
+  FOCUSED="$FOCUSED_WORKSPACE"
+  mkdir -p "${FOCUSED_CACHE:h}" 2>/dev/null || true
+  print -r -- "$FOCUSED" >|"$FOCUSED_CACHE"
+elif [[ -r "$FOCUSED_CACHE" ]]; then
+  FOCUSED=$(<"$FOCUSED_CACHE")
+else
+  FOCUSED=$(aerospace list-workspaces --focused 2>/dev/null)
+fi
+
+# Extract workspace name from item name (space.email -> email)
+WORKSPACE="${NAME#space.}"
+
+# Check for tmux bell state from cache file (persists across events)
+# Written by tmux/scripts/bell-cache-updater.sh
+BELL_CACHE="$HOME/.cache/tmux-bell-active"
+if [[ -f "$BELL_CACHE" ]]; then
+  BELL_ACTIVE=$(cat "$BELL_CACHE" 2>/dev/null)
+else
+  BELL_ACTIVE="0"
+fi
+
+# Determine state: bell > active > inactive
+if [[ "$WORKSPACE" == "code" && "$BELL_ACTIVE" == "1" ]]; then
+  # Bell state: code workspace has pending notification (shows even when focused)
+  sketchybar --set "$NAME" \
+    icon.color="$BELL_FG" \
+    background.color="$BELL_BG" \
+    background.drawing=on
+elif [[ "$WORKSPACE" == "$FOCUSED" ]]; then
+  # Active workspace: prominent color with subtle background
+  sketchybar --set "$NAME" \
+    icon.color="$WORKSPACE_ACTIVE_FG" \
+    background.color="$WORKSPACE_ACTIVE_BG" \
+    background.drawing=on
+else
+  # Inactive workspace: dim color, transparent background
+  sketchybar --set "$NAME" \
+    icon.color="$WORKSPACE_INACTIVE_FG" \
+    background.color="$WORKSPACE_INACTIVE_BG" \
+    background.drawing=off
+fi

--- a/sketchybar/.config/sketchybar/plugins/battery.sh
+++ b/sketchybar/.config/sketchybar/plugins/battery.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env zsh
+# Battery plugin
+
+source "$HOME/.config/sketchybar/colors.sh"
+
+PERCENTAGE=$(pmset -g batt | grep -Eo "\d+%" | cut -d% -f1)
+CHARGING=$(pmset -g batt | grep 'AC Power')
+
+if [[ -z "$PERCENTAGE" ]]; then
+  sketchybar --set "$NAME" drawing=off
+  exit 0
+fi
+
+# Battery icon based on charge level
+case "${PERCENTAGE}" in
+100) ICON="󰁹" ;;
+9[0-9]) ICON="󰂂" ;;
+8[0-9]) ICON="󰂁" ;;
+7[0-9]) ICON="󰂀" ;;
+6[0-9]) ICON="󰁿" ;;
+5[0-9]) ICON="󰁾" ;;
+4[0-9]) ICON="󰁽" ;;
+3[0-9]) ICON="󰁼" ;;
+2[0-9]) ICON="󰁻" ;;
+1[0-9]) ICON="󰁺" ;;
+*) ICON="󰂃" ;;
+esac
+
+if [[ -n "$CHARGING" ]]; then
+  ICON="󰂄"
+fi
+
+if [[ "$PERCENTAGE" -lt 25 ]]; then
+  ICON_CLR="$DANGER_COLOR"
+  LABEL_CLR="$DANGER_COLOR"
+elif [[ "$PERCENTAGE" -lt 50 ]]; then
+  ICON_CLR="$WARN_COLOR"
+  LABEL_CLR="$WARN_COLOR"
+else
+  ICON_CLR="$ICON_COLOR"
+  LABEL_CLR="$LABEL_COLOR"
+fi
+
+sketchybar --set "$NAME" \
+  icon="$ICON" \
+  icon.color="$ICON_CLR" \
+  label="${PERCENTAGE}%" \
+  label.color="$LABEL_CLR" \
+  drawing=on

--- a/sketchybar/.config/sketchybar/plugins/clock.sh
+++ b/sketchybar/.config/sketchybar/plugins/clock.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env zsh
+# Clock plugin - time only with meeting reminder highlighting.
+# SACRED: minutes 00, 29, 30, 59 highlight in the notify color so a meeting
+# never gets missed — 1 minute before and right at the start of every half
+# hour. Preserve this exactly; ported from v1's date.sh/clock.sh unchanged
+# except the color source.
+
+source "$HOME/.config/sketchybar/colors.sh"
+
+TIME=$(date '+%H:%M')
+MINUTE=$(date '+%M')
+
+if [[ "$MINUTE" == "00" || "$MINUTE" == "29" || "$MINUTE" == "30" || "$MINUTE" == "59" ]]; then
+  COLOR="$TIME_HIGHLIGHT"
+else
+  COLOR="$TIME_NORMAL"
+fi
+
+sketchybar --set "$NAME" \
+  icon.color="$COLOR" \
+  label="$TIME" \
+  label.color="$COLOR"

--- a/sketchybar/.config/sketchybar/plugins/cpu.sh
+++ b/sketchybar/.config/sketchybar/plugins/cpu.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env zsh
+# CPU usage plugin
+
+source "$HOME/.config/sketchybar/colors.sh"
+
+# Get CPU usage using top
+CPU=$(top -l 1 -n 0 2>/dev/null | grep "CPU usage" | awk '{print int($3)}')
+
+if [[ -z "$CPU" ]]; then
+  CPU="--"
+  ICON_CLR="$ICON_COLOR"
+  LABEL_CLR="$LABEL_COLOR"
+else
+  if [[ "$CPU" -gt 75 ]]; then
+    ICON_CLR="$DANGER_COLOR"
+    LABEL_CLR="$DANGER_COLOR"
+  elif [[ "$CPU" -gt 50 ]]; then
+    ICON_CLR="$WARN_COLOR"
+    LABEL_CLR="$WARN_COLOR"
+  else
+    ICON_CLR="$ICON_COLOR"
+    LABEL_CLR="$LABEL_COLOR"
+  fi
+fi
+
+sketchybar --set "$NAME" label="${CPU}%" icon.color="$ICON_CLR" label.color="$LABEL_CLR"

--- a/sketchybar/.config/sketchybar/plugins/date.sh
+++ b/sketchybar/.config/sketchybar/plugins/date.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh
+# Date plugin - displays current date with calendar icon
+# Uses the accent color, which follows the pokemon
+
+source "$HOME/.config/sketchybar/colors.sh"
+
+DATE=$(date '+%a %b %d')
+
+sketchybar --set "$NAME" \
+  icon.color="$ACCENT_COLOR" \
+  label="$DATE" \
+  label.color="$ACCENT_COLOR"

--- a/sketchybar/.config/sketchybar/plugins/memory.sh
+++ b/sketchybar/.config/sketchybar/plugins/memory.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env zsh
+# Memory usage plugin
+
+source "$HOME/.config/sketchybar/colors.sh"
+
+# Get memory pressure percentage (more reliable on macOS)
+MEM_PRESSURE=$(memory_pressure 2>/dev/null | grep "System-wide memory free percentage" | awk '{print int($5)}')
+
+if [[ -n "$MEM_PRESSURE" ]]; then
+  MEM=$((100 - MEM_PRESSURE))
+else
+  MEM="--"
+fi
+
+if [[ "$MEM" == "--" ]]; then
+  ICON_CLR="$ICON_COLOR"
+  LABEL_CLR="$LABEL_COLOR"
+elif [[ "$MEM" -gt 75 ]]; then
+  ICON_CLR="$DANGER_COLOR"
+  LABEL_CLR="$DANGER_COLOR"
+elif [[ "$MEM" -gt 50 ]]; then
+  ICON_CLR="$WARN_COLOR"
+  LABEL_CLR="$WARN_COLOR"
+else
+  ICON_CLR="$ICON_COLOR"
+  LABEL_CLR="$LABEL_COLOR"
+fi
+
+sketchybar --set "$NAME" label="${MEM}%" icon.color="$ICON_CLR" label.color="$LABEL_CLR"

--- a/sketchybar/.config/sketchybar/plugins/theme-sync.sh
+++ b/sketchybar/.config/sketchybar/plugins/theme-sync.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env zsh
+# Runs off its own item's update_freq. sketchybar has no "just re-source and
+# everything restyles" primitive like tmux's @variables, so when the
+# rendered colors file changes mtime, this recolors the bar chrome directly
+# and fires pokemon_colors_changed for items that don't refresh often enough
+# on their own (date, workspaces) — mirrors tmux's theme-sync.sh convergence.
+source "$HOME/.config/sketchybar/colors.sh"
+
+COLORS_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/generated/sketchybar-colors.sh"
+CACHE="$HOME/.cache/sketchybar-colors-mtime"
+
+[[ -f "$COLORS_FILE" ]] || exit 0
+
+MTIME=$(stat -f %m "$COLORS_FILE" 2>/dev/null || stat -c %Y "$COLORS_FILE" 2>/dev/null)
+SEEN=""
+[[ -f "$CACHE" ]] && SEEN=$(<"$CACHE")
+
+[[ "$MTIME" == "$SEEN" ]] && exit 0
+
+sketchybar --bar color="$BAR_COLOR" border_color="$BORDER_COLOR" \
+  --default icon.color="$ICON_COLOR" label.color="$LABEL_COLOR" \
+  --trigger pokemon_colors_changed
+
+mkdir -p "${CACHE:h}"
+print -r -- "$MTIME" >|"$CACHE"

--- a/sketchybar/.config/sketchybar/plugins/wifi.sh
+++ b/sketchybar/.config/sketchybar/plugins/wifi.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env zsh
+# WiFi status plugin - uses ipconfig getsummary for reliable SSID detection
+# The ipconfig method works without requiring location permissions on macOS Sonoma+
+# See: https://github.com/FelixKratz/SketchyBar/issues/407
+
+source "$HOME/.config/sketchybar/colors.sh"
+
+# Get ipconfig summary - if WiFi is off, this returns minimal/no data
+IPCONFIG_OUTPUT=$(/usr/sbin/ipconfig getsummary en0 2>&1)
+
+# Get SSID from the output
+SSID=$(echo "$IPCONFIG_OUTPUT" | awk -F' : ' '/ SSID/ { print $2 }')
+
+# Check if WiFi interface is active (look for RouterARPVerified or similar active indicators)
+WIFI_ACTIVE=$(echo "$IPCONFIG_OUTPUT" | grep -c "SSID")
+
+if [[ "$WIFI_ACTIVE" -eq 0 && "$IPCONFIG_OUTPUT" != *"SSID"* ]]; then
+  # WiFi is off - no SSID field in output at all
+  ICON="󰖪"
+  COLOR="$DANGER_COLOR"
+  LABEL=""
+elif [[ -z "$SSID" ]]; then
+  # WiFi on but not connected to any network
+  ICON="󰤯"
+  COLOR="$WARN_COLOR"
+  LABEL=""
+else
+  # Connected - show network name
+  ICON="󰖩"
+  COLOR="$ICON_COLOR"
+  LABEL="$SSID"
+fi
+
+sketchybar --set "$NAME" \
+  icon="$ICON" \
+  icon.color="$COLOR" \
+  label.color="$LABEL_COLOR" \
+  label="$LABEL" \
+  label.drawing=$([[ -n "$LABEL" ]] && echo "on" || echo "off")

--- a/sketchybar/.config/sketchybar/sketchybarrc
+++ b/sketchybar/.config/sketchybar/sketchybarrc
@@ -1,0 +1,194 @@
+#!/usr/bin/env zsh
+# Sketchybar configuration
+# Floating rounded bar, themed with the v2 token pipeline (colors.sh) and
+# pokemon color accents
+#
+# Layout:
+# - Left: Date, Aerospace workspace indicators (V B N M 1 2 3)
+# - Right: CPU, Memory, WiFi, Battery, Clock
+
+setopt ERR_EXIT NO_UNSET PIPE_FAIL
+
+# -----------------------------------------------------------------------------
+# Configuration Paths
+# -----------------------------------------------------------------------------
+CONFIG_DIR="$HOME/.config/sketchybar"
+PLUGIN_DIR="$CONFIG_DIR/plugins"
+
+# Load color definitions (sources the rendered theme colors)
+source "$CONFIG_DIR/colors.sh"
+
+# -----------------------------------------------------------------------------
+# Bar Configuration
+# -----------------------------------------------------------------------------
+# Floating rounded bar
+bar=(
+  position=top
+  height=32
+  margin=10
+  corner_radius=10
+  color="$BAR_COLOR"
+  border_color="$BORDER_COLOR"
+  border_width=1
+  blur_radius=30
+  shadow=on
+  sticky=on
+  topmost=off
+  y_offset=10
+  notch_width=0
+)
+sketchybar --bar "${bar[@]}"
+
+# -----------------------------------------------------------------------------
+# Default Item Configuration
+# -----------------------------------------------------------------------------
+default=(
+  padding_left=4
+  padding_right=4
+  background.height=26
+  background.corner_radius=6
+  icon.font="JetBrainsMono Nerd Font:Bold:12.0"
+  icon.color="$ICON_COLOR"
+  icon.padding_left=0
+  icon.padding_right=6
+  label.font="JetBrainsMono Nerd Font:Regular:12.0"
+  label.color="$LABEL_COLOR"
+  label.padding_left=0
+  label.padding_right=12
+)
+sketchybar --default "${default[@]}"
+
+# -----------------------------------------------------------------------------
+# Custom Events (must be defined before items subscribe to them)
+# -----------------------------------------------------------------------------
+sketchybar --add event aerospace_workspace_change
+sketchybar --add event pokemon_colors_changed
+sketchybar --add event tmux_bell_change
+
+# -----------------------------------------------------------------------------
+# Theme convergence (Left, invisible) - see plugins/theme-sync.sh
+# -----------------------------------------------------------------------------
+# `theme` only ever writes the rendered colors file; it never pokes running
+# processes (see theme/.local/bin/theme). This item polls that file's mtime
+# every 5s and fans out a recolor when it changes - the sketchybar analogue
+# of tmux's status-interval theme-sync.sh.
+sketchybar --add item theme_sync left \
+  --set theme_sync \
+  drawing=off \
+  update_freq=5 \
+  script="$PLUGIN_DIR/theme-sync.sh"
+
+# -----------------------------------------------------------------------------
+# Date (Left - far left, before workspaces)
+# -----------------------------------------------------------------------------
+sketchybar --add item date left \
+  --set date \
+  update_freq=60 \
+  icon="󰃭 " \
+  icon.color="$ACCENT_COLOR" \
+  label.color="$ACCENT_COLOR" \
+  background.color="$ITEM_BG" \
+  script="$PLUGIN_DIR/date.sh" \
+  --subscribe date system_woke pokemon_colors_changed
+
+# -----------------------------------------------------------------------------
+# Aerospace Workspace Indicators (Left)
+# -----------------------------------------------------------------------------
+# Display keybinding letters matching aerospace.toml keybindings
+# Using zsh associative array (works in zsh 5.9)
+# Keys align with bottom row (V B N M) and match monitor layout left-to-right
+typeset -A WORKSPACE_KEYS
+WORKSPACE_KEYS=(
+  message "V" # mail/messages (left monitor)
+  browser "B" # center monitor
+  code "N"    # center monitor
+  meeting "M" # Teams meetings (right monitor)
+  monitor-1 "1"
+  monitor-2 "2"
+  monitor-3 "3"
+)
+
+# Workspace order (left to right in bar, matches monitor layout)
+WORKSPACES=("monitor-1" "monitor-2" "monitor-3" "message" "browser" "code" "meeting")
+
+for workspace in "${WORKSPACES[@]}"; do
+  key="${WORKSPACE_KEYS[$workspace]}"
+  sketchybar --add item "space.$workspace" left \
+    --set "space.$workspace" \
+    icon="$key" \
+    icon.font="JetBrainsMono Nerd Font:Bold:11.0" \
+    icon.padding_left=8 \
+    icon.padding_right=8 \
+    label.drawing=off \
+    background.color="$WORKSPACE_INACTIVE_BG" \
+    background.corner_radius=6 \
+    background.height=22 \
+    click_script="aerospace workspace $workspace" \
+    script="$PLUGIN_DIR/aerospace.sh"
+
+  # Subscribe to events - code workspace also listens for tmux bell changes
+  if [[ "$workspace" == "code" ]]; then
+    sketchybar --subscribe "space.$workspace" aerospace_workspace_change pokemon_colors_changed tmux_bell_change
+  else
+    sketchybar --subscribe "space.$workspace" aerospace_workspace_change pokemon_colors_changed
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# Right Side Items (ordered right-to-left)
+# -----------------------------------------------------------------------------
+
+# Clock (rightmost) - time with clock icon
+# Highlights in the notify color at meeting reminder times (00, 29, 30, 59
+# minutes) - see plugins/clock.sh
+sketchybar --add item clock right \
+  --set clock \
+  update_freq=15 \
+  icon="󰥔" \
+  icon.font="JetBrainsMono Nerd Font:Bold:14.0" \
+  label.font="JetBrainsMono Nerd Font:Bold:12.0" \
+  background.color="$ITEM_BG" \
+  script="$PLUGIN_DIR/clock.sh" \
+  label.padding_right=0 \
+  --subscribe clock system_woke pokemon_colors_changed
+
+# Battery
+sketchybar --add item battery right \
+  --set battery \
+  update_freq=60 \
+  label.padding_right=8 \
+  background.color="$ITEM_BG" \
+  script="$PLUGIN_DIR/battery.sh" \
+  --subscribe battery power_source_change system_woke
+
+# WiFi - clickable, opens the Network settings pane
+sketchybar --add item wifi right \
+  --set wifi \
+  update_freq=30 \
+  background.color="$ITEM_BG" \
+  script="$PLUGIN_DIR/wifi.sh" \
+  click_script='open "x-apple.systempreferences:com.apple.Network-Settings.extension"' \
+  --subscribe wifi wifi_change
+
+# Memory (with icon)
+sketchybar --add item memory right \
+  --set memory \
+  update_freq=10 \
+  icon="󰍛" \
+  icon.font="JetBrainsMono Nerd Font:Bold:14.0" \
+  background.color="$ITEM_BG" \
+  script="$PLUGIN_DIR/memory.sh"
+
+# CPU (with icon)
+sketchybar --add item cpu right \
+  --set cpu \
+  update_freq=5 \
+  icon="󰌢" \
+  icon.font="JetBrainsMono Nerd Font:Bold:14.0" \
+  background.color="$ITEM_BG" \
+  script="$PLUGIN_DIR/cpu.sh"
+
+# -----------------------------------------------------------------------------
+# Force Initial Update
+# -----------------------------------------------------------------------------
+sketchybar --update

--- a/theme/.config/theme/templates/sketchybar-colors.sh.tmpl
+++ b/theme/.config/theme/templates/sketchybar-colors.sh.tmpl
@@ -1,0 +1,34 @@
+#!/usr/bin/env zsh
+# Rendered by `theme` — do not edit; change this template or tokens instead.
+# Sourced by sketchybarrc and every plugin (see sketchybar/.config/sketchybar/
+# colors.sh). ARGB strings for sketchybar's own color format, built from the
+# bare-hex-digit variant `theme` emits alongside every color token.
+
+export BAR_COLOR="0xff{{bg_hex}}"
+export ITEM_BG="0x00000000"
+export BORDER_COLOR="0xff{{border_hex}}"
+
+export ICON_COLOR="0xff{{fg_muted_hex}}"
+export LABEL_COLOR="0xff{{fg_muted_hex}}"
+
+# Pokemon-linked: theme pokemon <name> overrides these two only.
+export ACCENT_COLOR="0xff{{accent_hex}}"
+export NOTIFY_COLOR="0xff{{notify_hex}}"
+
+export WORKSPACE_ACTIVE_FG="0xff{{accent_hex}}"
+export WORKSPACE_ACTIVE_BG="0x33{{accent_hex}}"
+export WORKSPACE_INACTIVE_FG="0xff{{fg_muted_hex}}"
+export WORKSPACE_INACTIVE_BG="0x00000000"
+
+# The clock's meeting-warning state (see plugins/clock.sh).
+export TIME_NORMAL="0xff{{accent_hex}}"
+export TIME_HIGHLIGHT="0xff{{notify_hex}}"
+
+export BELL_FG="0xff{{notify_hex}}"
+export BELL_BG="0x33{{notify_hex}}"
+
+# Threshold colors for battery/cpu/memory. warn is a semantic token; danger
+# has no role of its own, so it names the red palette hue directly (see
+# starship.toml.tmpl's use of raw palette keys for the same pattern).
+export WARN_COLOR="0xff{{warn_hex}}"
+export DANGER_COLOR="0xff{{red_hex}}"

--- a/tiers/core.txt
+++ b/tiers/core.txt
@@ -4,3 +4,4 @@ theme
 tmux
 workmux
 rail
+bat

--- a/tiers/mac.txt
+++ b/tiers/mac.txt
@@ -1,2 +1,3 @@
 hammerspoon
 ghostty
+sketchybar

--- a/zsh/.config/zsh/aliases.zsh
+++ b/zsh/.config/zsh/aliases.zsh
@@ -22,6 +22,8 @@ alias ~='cd ~'
 # System utilities
 alias df='df -h'
 alias du='du -h'
+# apt installs bat's binary as batcat to avoid clashing with bacula-console.
+command -v batcat >/dev/null 2>&1 && alias bat='batcat'
 # alias grep='grep --color=auto' -- commenting due to claude using grep a lot
 
 # Claude Code: unset TMUX env so the binary's hardcoded chalk-level cap


### PR DESCRIPTION
## Summary

- **bat**: new `bat` stow package. `--theme-dark`/`--theme-light` set to
  Catppuccin Mocha/Latte (bat auto-selects by terminal darkness), with the
  two upstream `catppuccin/bat` tmThemes vendored in. Added to
  `tiers/core.txt`; `install.sh` installs `bat` via brew/apt and runs
  `bat cache --build` after stow. apt names the binary `batcat` — aliased in
  `zsh/aliases.zsh`.
- **sketchybar**: new `sketchybar` stow package, porting v1's bar 1:1
  (aerospace, battery, clock, cpu, date, memory, wifi), rethemed onto the v2
  token pipeline via a new `sketchybar-colors.sh.tmpl` template — no
  hardcoded hexes in the package. Since `theme` only ever writes files and
  never pokes processes, and sketchybar has no live-restyle primitive like
  tmux's `@variables`, a `theme_sync` bar item polls the rendered file's
  mtime and fans a recolor out (bar chrome directly, plus a
  `pokemon_colors_changed` event for items that don't refresh often enough
  on their own) — the sketchybar analogue of tmux's `theme-sync.sh`.
  Added `sketchybar` to `tiers/mac.txt`; `install.sh` installs it via brew
  on the mac tier.
- The meeting-warning clock (highlights at :00, :29, :30, :59 so a meeting
  is never missed) is preserved exactly from v1 — only the color sourcing
  changed.
- New: the wifi item is now clickable, opening the Network settings pane
  (`x-apple.systempreferences:com.apple.Network-Settings.extension` —
  verified it resolves directly to the Network pane on this macOS 14.4
  machine).
- `.pre-commit-config.yaml`: sketchybar's plugins are zsh (shebang, not
  extension) and shellcheck has no zsh dialect, so they're excluded from
  the shellcheck hook the same way `.zsh` files already are. shfmt still
  covers them.

## Post-merge step (live machine)

After merging and running `install.sh` on the live machine, `bat cache
--build` needs a fresh run so the vendored themes take effect (install.sh
now does this automatically going forward, but the live machine's cache
predates this branch).

## Test plan

- [x] `uvx prek run --all-files` green
- [x] `theme apply dark` / `theme apply light` render
  `sketchybar-colors.sh` with zero unresolved tokens, in a scratch
  `HOME`/`XDG_STATE_HOME` (stowed `theme` + `sketchybar` + `bat`)
- [x] `theme pokemon raikou` correctly overrides `ACCENT_COLOR`/
  `NOTIFY_COLOR` in the generated sketchybar colors file
- [x] `zsh -n` clean on every changed/new zsh file
- [x] bat, pointed at the vendored themes via `BAT_CONFIG_DIR`, renders
  `--theme=dark`/`--theme=light` with correct Mocha/Latte syntax colors
- [x] verified the wifi click URL opens the Network pane directly (not
  just System Settings) on this machine
- [ ] Ryan demos from this worktree and confirms before merge (per the
  handoff, this branch must not be merged without that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)